### PR TITLE
Extract external libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .pioenvs
+.pio
 
 .clang_complete
 .gcc-flags.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.pio
 .pioenvs
 .pio
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+# Continuous Integration (CI) is the practice, in software
+# engineering, of merging all developer working copies with a shared mainline
+# several times a day < https://docs.platformio.org/page/ci/index.html >
+#
+# Documentation:
+#
+# * Travis CI Embedded Builds with PlatformIO
+#   < https://docs.travis-ci.com/user/integration/platformio/ >
+#
+# * PlatformIO integration with Travis CI
+#   < https://docs.platformio.org/page/ci/travis.html >
+#
+# * User Guide for `platformio ci` command
+#   < https://docs.platformio.org/page/userguide/cmd_ci.html >
+#
+language: python
+python:
+  - "3.7.5"
+
+sudo: false
+cache:
+  directories:
+    - "~/.platformio"
+
+install:
+  - pip install -U platformio
+  - platformio update
+
+script:
+  - platformio ci --lib="./src" -c platformio.ini ./examples/simple/

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
   - platformio update
 
 script:
-  - platformio ci --lib="./src" -c platformio.ini ./examples/simple/
+  - platformio ci -c platformio.ini --lib="./src" --lib="./lib/*" ./examples/simple/
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,9 @@
-# Continuous Integration (CI) is the practice, in software
-# engineering, of merging all developer working copies with a shared mainline
-# several times a day < https://docs.platformio.org/page/ci/index.html >
-#
-# Documentation:
-#
-# * Travis CI Embedded Builds with PlatformIO
-#   < https://docs.travis-ci.com/user/integration/platformio/ >
-#
-# * PlatformIO integration with Travis CI
-#   < https://docs.platformio.org/page/ci/travis.html >
-#
-# * User Guide for `platformio ci` command
-#   < https://docs.platformio.org/page/userguide/cmd_ci.html >
-#
+sudo: false
+
 language: python
 python:
-  - "3.7.5"
+  - "2.7"
 
-sudo: false
 cache:
   directories:
     - "~/.platformio"
@@ -28,3 +14,8 @@ install:
 
 script:
   - platformio ci --lib="./src" -c platformio.ini ./examples/simple/
+
+notifications:
+  email:
+    on_success: never
+    on_failure: always

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ![Logo](http://svg.wiersma.co.za/github/project?lang=cpp&title=ConfigManager&tag=wifi%20configuration%20manager)
 
+[![Build Status](https://travis-ci.com/nrwiersma/ConfigManager.svg?branch=master)](https://travis-ci.com/nrwiersma/ConfigManager)
 [![arduino-library-badge](http://www.ardu-badge.com/badge/ConfigManager.svg)](http://www.ardu-badge.com/ConfigManager)
 
 Wifi connection and configuration manager for ESP8266 and ESP32.
@@ -109,7 +110,7 @@ on the most common IDEs:
 
 ### Enabling
 
-By default, ConfigManager runs in `DEBUG_MODE` off. This is to allow the serial iterface to communicate as needed. 
+By default, ConfigManager runs in `DEBUG_MODE` off. This is to allow the serial iterface to communicate as needed.
 To turn on debugging, add the following line inside your `setup` routine:
 
 ```
@@ -295,7 +296,7 @@ ssid=access point&password=some password
 ```json
 {
   "ssid": "access point name",
-  "strength": *int*, 
+  "strength": *int*,
   "security": *bool*
 }
 ```

--- a/lib/ConfigParameter/BaseParameter.h
+++ b/lib/ConfigParameter/BaseParameter.h
@@ -1,0 +1,18 @@
+#ifndef __BASE_PARAMETER_H__
+#define __BASE_PARAMETER_H__
+
+enum Mode {ap, api};
+enum ParameterMode { get, set, both};
+
+/**
+ * Base Parameter
+ */
+class BaseParameter {
+public:
+    virtual ParameterMode getMode() = 0;
+    virtual void fromJson(JsonObject *json) = 0;
+    virtual void toJson(JsonObject *json) = 0;
+    virtual void clearData() = 0;
+};
+
+#endif /* __BASE_PARAMETER_H__ */

--- a/lib/ConfigParameter/BaseParameter.h
+++ b/lib/ConfigParameter/BaseParameter.h
@@ -4,7 +4,6 @@
 #include <ArduinoJson.h>
 #include <DebugPrint.h>
 
-enum Mode {ap, api};
 enum ParameterMode { get, set, both};
 
 /**

--- a/lib/ConfigParameter/BaseParameter.h
+++ b/lib/ConfigParameter/BaseParameter.h
@@ -1,6 +1,8 @@
 #ifndef __BASE_PARAMETER_H__
 #define __BASE_PARAMETER_H__
 
+#include <DebugPrint.h>
+
 enum Mode {ap, api};
 enum ParameterMode { get, set, both};
 

--- a/lib/ConfigParameter/BaseParameter.h
+++ b/lib/ConfigParameter/BaseParameter.h
@@ -1,6 +1,7 @@
 #ifndef __BASE_PARAMETER_H__
 #define __BASE_PARAMETER_H__
 
+#include <ArduinoJson.h>
 #include <DebugPrint.h>
 
 enum Mode {ap, api};

--- a/lib/ConfigParameter/ConfigParameter.h
+++ b/lib/ConfigParameter/ConfigParameter.h
@@ -1,0 +1,45 @@
+#ifndef __CONFIG_PARAMETER_H__
+#define __CONFIG_PARAMETER_H_
+
+#include "BaseParameter.h"
+
+/**
+ * Config Parameter
+ */
+template<typename T>
+class ConfigParameter : public BaseParameter {
+public:
+    ConfigParameter(const char *name, T *ptr, ParameterMode mode = both) {
+        this->name = name;
+        this->ptr = ptr;
+        this->mode = mode;
+    }
+
+    ParameterMode getMode() {
+        return this->mode;
+    }
+
+    void fromJson(JsonObject *json) {
+        if (json->containsKey(name) && json->is<T>(name)) {
+            *ptr = json->get<T>(name);
+        }
+    }
+
+    void toJson(JsonObject *json) {
+        json->set(name, *ptr);
+    }
+
+    void clearData() {
+        DebugPrint("Clearing: ");
+        DebugPrintln(name);
+        *ptr = T();
+    }
+
+private:
+    const char *name;
+    T *ptr;
+    std::function<void(const char*)> cb;
+    ParameterMode mode;
+};
+
+#endif /* __CONFIG_PARAMETER_H__ */

--- a/lib/ConfigParameter/ConfigParameter.h
+++ b/lib/ConfigParameter/ConfigParameter.h
@@ -1,7 +1,7 @@
 #ifndef __CONFIG_PARAMETER_H__
 #define __CONFIG_PARAMETER_H_
 
-#include "BaseParameter.h"
+#include <BaseParameter.h>
 
 /**
  * Config Parameter

--- a/lib/ConfigParameter/ConfigParameter.h
+++ b/lib/ConfigParameter/ConfigParameter.h
@@ -38,7 +38,6 @@ public:
 private:
     const char *name;
     T *ptr;
-    std::function<void(const char*)> cb;
     ParameterMode mode;
 };
 

--- a/lib/ConfigParameter/ConfigParameter.h
+++ b/lib/ConfigParameter/ConfigParameter.h
@@ -1,5 +1,5 @@
 #ifndef __CONFIG_PARAMETER_H__
-#define __CONFIG_PARAMETER_H_
+#define __CONFIG_PARAMETER_H__
 
 #include <BaseParameter.h>
 

--- a/lib/ConfigParameter/ConfigStringParameter.h
+++ b/lib/ConfigParameter/ConfigStringParameter.h
@@ -1,0 +1,50 @@
+#ifndef CONFIG_STRING_PARAMETER_H__
+#define __CONFIG_STRING_PARAMETER_H__
+
+#include "BaseParameter.h"
+
+/**
+ * Config String Parameter
+ */
+class ConfigStringParameter : public BaseParameter {
+public:
+    ConfigStringParameter(const char *name, char *ptr, size_t length, ParameterMode mode = both) {
+        this->name = name;
+        this->ptr = ptr;
+        this->length = length;
+        this->mode = mode;
+    }
+
+    ParameterMode getMode() {
+        return this->mode;
+    }
+
+    void fromJson(JsonObject *json) {
+        if (json->containsKey(name) && json->is<char *>(name)) {
+            const char * value = json->get<const char *>(name);
+
+            memset(ptr, NULL, length);
+            strncpy(ptr, const_cast<char*>(value), length - 1);
+        }
+    }
+
+    void toJson(JsonObject *json) {
+        json->set(name, ptr);
+    }
+
+    void clearData() {
+        DebugPrint("Clearing: ");
+        DebugPrintln(name);
+        memset(ptr, NULL, length);
+    }
+    
+
+private:
+    const char *name;
+    char *ptr;
+    size_t length;
+    ParameterMode mode;
+};
+
+
+#endif /* __CONFIG_STRING_PARAMETER_H__ */

--- a/lib/ConfigParameter/ConfigStringParameter.h
+++ b/lib/ConfigParameter/ConfigStringParameter.h
@@ -1,7 +1,7 @@
 #ifndef CONFIG_STRING_PARAMETER_H__
 #define __CONFIG_STRING_PARAMETER_H__
 
-#include "BaseParameter.h"
+#include <BaseParameter.h>
 
 /**
  * Config String Parameter

--- a/lib/ConfigParameter/ConfigStringParameter.h
+++ b/lib/ConfigParameter/ConfigStringParameter.h
@@ -1,4 +1,4 @@
-#ifndef CONFIG_STRING_PARAMETER_H__
+#ifndef __CONFIG_STRING_PARAMETER_H__
 #define __CONFIG_STRING_PARAMETER_H__
 
 #include <BaseParameter.h>

--- a/lib/DebugPrint/DebugPrint.h
+++ b/lib/DebugPrint/DebugPrint.h
@@ -1,0 +1,9 @@
+#ifndef __DEBUG_PRINT_H__
+#define __DEBUG_PRINT_H__
+
+extern bool DEBUG_MODE;
+
+#define DebugPrintln(a) (DEBUG_MODE ? Serial.println(a) : false)
+#define DebugPrint(a) (DEBUG_MODE ? Serial.print(a) : false)
+
+#endif /* __DEBUG_PRINT_H__ */

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "ConfigManager",
-  "version": "1.5",
+  "version": "1.5.1",
   "keywords": "wifi, wi-fi, config",
   "description": "WiFi connection manager for ESP8266 and ESP32",
   "repository":

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ConfigManager
-version=1.5
+version=1.5.1
 author=Nick Wiersma <nick@wiersma.co.za>
 maintainer=Nick Wiersma <nick@wiersma.co.za>
 sentence=WiFi connection manager for ESP8266 and ESP32

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,28 @@
+[platformio]
+default_envs = nodemcuv2
+
+[common]
+lib_deps =
+  ArduinoJson@5.13.4
+
+[env:nodemcuv2]
+platform = https://github.com/platformio/platform-espressif8266.git
+board = d1_mini
+framework = arduino
+monitor_speed = 115200
+build_flags = -std=c++11, -Wl,-Teagle.flash.4m3m.ld, -D PIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH, -DARDUINO_ARCH_ESP8266
+lib_ldf_mode = deep
+board_build.f_flash = 80000000L
+upload_speed = 115200
+lib_deps = ${common.lib_deps}
+test_filter = embedded
+
+[env:esp32]
+platform = https://github.com/platformio/platform-espressif32.git
+board = esp-wrover-kit
+framework = arduino
+board_build.partitions = noota_3g.csv
+build_flags = -std=c++11, -DARDUINO_ARCH_ESP32
+lib_ldf_mode = deep
+lib_deps = ${common.lib_deps}
+test_filter = embedded

--- a/src/ConfigManager.h
+++ b/src/ConfigManager.h
@@ -24,7 +24,6 @@
     #define WIFI_OPEN  WIFI_AUTH_OPEN
 #endif
 
-#include "DebugPrint.h"
 #include "ConfigParameter.h"
 #include "ConfigStringParameter.h"
 

--- a/src/ConfigManager.h
+++ b/src/ConfigManager.h
@@ -42,6 +42,8 @@ extern const char mimePlain[];
 extern const char mimeCSS[];
 extern const char mimeJS[];
 
+enum Mode {ap, api};
+
 /**
  * Config Manager
  */

--- a/src/ConfigManager.h
+++ b/src/ConfigManager.h
@@ -18,6 +18,12 @@
 #include <list>
 #include "ArduinoJson.h"
 
+#if defined(ARDUINO_ARCH_ESP8266) //ESP8266
+    #define WIFI_OPEN  ENC_TYPE_NONE
+#elif defined(ARDUINO_ARCH_ESP32) //ESP32
+    #define WIFI_OPEN  WIFI_AUTH_OPEN
+#endif
+
 #define MAGIC_LENGTH 2
 #define SSID_LENGTH 32
 #define PASSWORD_LENGTH 64
@@ -111,7 +117,7 @@ public:
         if (json->containsKey(name) && json->is<char *>(name)) {
             const char * value = json->get<const char *>(name);
 
-            memset(ptr, NULL, length);
+            memset(ptr, 0, length);
             strncpy(ptr, const_cast<char*>(value), length - 1);
         }
     }
@@ -123,9 +129,9 @@ public:
     void clearData() {
         DebugPrint("Clearing: ");
         DebugPrintln(name);
-        memset(ptr, NULL, length);
+        memset(ptr, 0, length);
     }
-    
+
 
 private:
     const char *name;

--- a/src/ConfigManager.h
+++ b/src/ConfigManager.h
@@ -24,6 +24,10 @@
     #define WIFI_OPEN  WIFI_AUTH_OPEN
 #endif
 
+#include "DebugPrint.h"
+#include "ConfigParameter.h"
+#include "ConfigStringParameter.h"
+
 #define MAGIC_LENGTH 2
 #define SSID_LENGTH 32
 #define PASSWORD_LENGTH 64
@@ -33,112 +37,11 @@
     using WebServer = ESP8266WebServer;
 #endif
 
-extern bool DEBUG_MODE;
-
-#define DebugPrintln(a) (DEBUG_MODE ? Serial.println(a) : false)
-#define DebugPrint(a) (DEBUG_MODE ? Serial.print(a) : false)
-
 extern const char mimeHTML[];
 extern const char mimeJSON[];
 extern const char mimePlain[];
 extern const char mimeCSS[];
 extern const char mimeJS[];
-
-enum Mode {ap, api};
-enum ParameterMode { get, set, both};
-
-/**
- * Base Parameter
- */
-class BaseParameter {
-public:
-    virtual ParameterMode getMode() = 0;
-    virtual void fromJson(JsonObject *json) = 0;
-    virtual void toJson(JsonObject *json) = 0;
-    virtual void clearData() = 0;
-};
-
-/**
- * Config Parameter
- */
-template<typename T>
-class ConfigParameter : public BaseParameter {
-public:
-    ConfigParameter(const char *name, T *ptr, ParameterMode mode = both) {
-        this->name = name;
-        this->ptr = ptr;
-        this->mode = mode;
-    }
-
-    ParameterMode getMode() {
-        return this->mode;
-    }
-
-    void fromJson(JsonObject *json) {
-        if (json->containsKey(name) && json->is<T>(name)) {
-            *ptr = json->get<T>(name);
-        }
-    }
-
-    void toJson(JsonObject *json) {
-        json->set(name, *ptr);
-    }
-
-    void clearData() {
-        DebugPrint("Clearing: ");
-        DebugPrintln(name);
-        *ptr = T();
-    }
-
-private:
-    const char *name;
-    T *ptr;
-    std::function<void(const char*)> cb;
-    ParameterMode mode;
-};
-
-/**
- * Config String Parameter
- */
-class ConfigStringParameter : public BaseParameter {
-public:
-    ConfigStringParameter(const char *name, char *ptr, size_t length, ParameterMode mode = both) {
-        this->name = name;
-        this->ptr = ptr;
-        this->length = length;
-        this->mode = mode;
-    }
-
-    ParameterMode getMode() {
-        return this->mode;
-    }
-
-    void fromJson(JsonObject *json) {
-        if (json->containsKey(name) && json->is<char *>(name)) {
-            const char * value = json->get<const char *>(name);
-
-            memset(ptr, 0, length);
-            strncpy(ptr, const_cast<char*>(value), length - 1);
-        }
-    }
-
-    void toJson(JsonObject *json) {
-        json->set(name, ptr);
-    }
-
-    void clearData() {
-        DebugPrint("Clearing: ");
-        DebugPrintln(name);
-        memset(ptr, 0, length);
-    }
-
-
-private:
-    const char *name;
-    char *ptr;
-    size_t length;
-    ParameterMode mode;
-};
 
 /**
  * Config Manager

--- a/test/embedded/ConfigParameterTest.h
+++ b/test/embedded/ConfigParameterTest.h
@@ -7,8 +7,59 @@ bool DEBUG_MODE = false;
 
 void test_sets_config_parameter_mode() {
   const char *variable = "baphled";
+  ConfigParameter<const char*> parameter = ConfigParameter<const char*>("username", &variable, both);
 
-  ConfigParameter<const char*> configParameters = ConfigParameter<const char*>("username", &variable, both);
+  TEST_ASSERT_EQUAL(both, parameter.getMode());
+}
 
-  TEST_ASSERT_EQUAL(configParameters.getMode(), both);
+void test_config_parameter_stored_as_json() {
+  const char *variable = "baphled";
+  const char *expected = "{\"username\":\"baphled\"}";
+  DynamicJsonBuffer jsonBuffer;
+  JsonObject& obj = jsonBuffer.createObject();
+
+  char body[50] = "\n";
+
+  ConfigParameter<const char*> parameter = ConfigParameter<const char*>("username", &variable, get);
+
+  parameter.toJson(&obj);
+  obj.printTo(body);
+
+  TEST_ASSERT_EQUAL_STRING(expected, body);
+}
+
+void test_config_parameter_stored_from_json() {
+  const char *variable = "foo";
+  const char *expected = "{\"username\":\"baphled\"}";
+  char body[50] = "\n";
+
+  DynamicJsonBuffer jsonBuffer;
+  JsonObject& obj = jsonBuffer.parseObject(expected);
+
+  ConfigParameter<const char*> parameter = ConfigParameter<const char*>("username", &variable, set);
+
+  parameter.fromJson(&obj);
+
+  parameter.toJson(&obj);
+  obj.printTo(body);
+
+  TEST_ASSERT_EQUAL_STRING(expected, body);
+}
+
+void test_config_parameter_clear_data() {
+  const char *variable = "foo";
+  const char *expected = "{\"username\":null}";
+  char body[50] = "\n";
+
+  DynamicJsonBuffer jsonBuffer;
+  JsonObject& obj = jsonBuffer.createObject();
+
+  ConfigParameter<const char*> parameter = ConfigParameter<const char*>("username", &variable, set);
+
+  parameter.clearData();
+
+  parameter.toJson(&obj);
+  obj.printTo(body);
+
+  TEST_ASSERT_EQUAL_STRING(expected, body);
 }

--- a/test/embedded/ConfigParameterTest.h
+++ b/test/embedded/ConfigParameterTest.h
@@ -1,0 +1,14 @@
+#include <unity.h>
+
+#include <stdio.h>
+#include <ConfigParameter.h>
+
+bool DEBUG_MODE = false;
+
+void test_sets_config_parameter_mode() {
+  const char *variable = "baphled";
+
+  ConfigParameter<const char*> configParameters = ConfigParameter<const char*>("username", &variable, both);
+
+  TEST_ASSERT_EQUAL(configParameters.getMode(), both);
+}

--- a/test/embedded/ConfigParameterTest.h
+++ b/test/embedded/ConfigParameterTest.h
@@ -3,8 +3,6 @@
 #include <stdio.h>
 #include <ConfigParameter.h>
 
-bool DEBUG_MODE = false;
-
 void test_sets_config_parameter_mode() {
   const char *variable = "baphled";
   ConfigParameter<const char*> parameter = ConfigParameter<const char*>("username", &variable, both);

--- a/test/embedded/ConfigStringParameterTest.h
+++ b/test/embedded/ConfigStringParameterTest.h
@@ -1,0 +1,67 @@
+#include <unity.h>
+
+#include <stdio.h>
+#include <ConfigStringParameter.h>
+
+void test_sets_config_string_parameter_mode() {
+  char *variable = "baphled";
+  size_t length = 10;
+  ConfigStringParameter parameter = ConfigStringParameter("username", variable, length, both);
+
+  TEST_ASSERT_EQUAL(both, parameter.getMode());
+}
+
+void test_config_string_parameter_stored_as_json() {
+  char *variable = "baphled";
+  const char *expected = "{\"username\":\"baphled\"}";
+  DynamicJsonBuffer jsonBuffer;
+  JsonObject& obj = jsonBuffer.createObject();
+
+  char body[50] = "\n";
+  size_t length = 10;
+
+  ConfigStringParameter parameter = ConfigStringParameter("username", variable, length, set);
+
+  parameter.toJson(&obj);
+  obj.printTo(body);
+
+  TEST_ASSERT_EQUAL_STRING(expected, body);
+}
+
+void test_config_string_parameter_stored_from_json() {
+  char *variable = "foo";
+  const char *expected = "{\"username\":\"baphled\"}";
+  char body[50] = "\n";
+  size_t length = 10;
+
+  DynamicJsonBuffer jsonBuffer;
+  JsonObject& obj = jsonBuffer.parseObject(expected);
+
+  ConfigStringParameter parameter = ConfigStringParameter("username", variable, length, set);
+
+  parameter.fromJson(&obj);
+
+  parameter.toJson(&obj);
+  obj.printTo(body);
+
+  TEST_ASSERT_EQUAL_STRING(expected, body);
+}
+
+void test_config_string_parameter_clear_data() {
+  char *variable = "foo";
+  const char *expected = "{\"username\":\"\"}";
+  char body[50] = "\n";
+  size_t length = 10;
+
+  DynamicJsonBuffer jsonBuffer;
+  JsonObject& obj = jsonBuffer.createObject();
+
+  ConfigStringParameter parameter = ConfigStringParameter("username", variable, length, set);
+
+  parameter.clearData();
+
+  parameter.toJson(&obj);
+  obj.printTo(body);
+
+  TEST_ASSERT_EQUAL_STRING(expected, body);
+}

--- a/test/embedded/main.cpp
+++ b/test/embedded/main.cpp
@@ -6,8 +6,11 @@
 #include "ConfigParameterTest.h"
 #include "ConfigStringParameterTest.h"
 
+bool DEBUG_MODE = false;
+
 void setup() {
   delay(2000);
+
   UNITY_BEGIN();
 
   // ConfigParameterTest

--- a/test/embedded/main.cpp
+++ b/test/embedded/main.cpp
@@ -1,0 +1,18 @@
+#if defined(ARDUINO) && defined(UNIT_TEST)
+#include "Arduino.h"
+
+#include <unity.h>
+
+#include "ConfigParameterTest.h"
+
+void setup() {
+  delay(2000);
+  UNITY_BEGIN();
+
+  RUN_TEST(test_sets_config_parameter_mode);
+
+  UNITY_END();
+}
+
+void loop() {}
+#endif

--- a/test/embedded/main.cpp
+++ b/test/embedded/main.cpp
@@ -10,6 +10,9 @@ void setup() {
   UNITY_BEGIN();
 
   RUN_TEST(test_sets_config_parameter_mode);
+  RUN_TEST(test_config_parameter_stored_as_json);
+  RUN_TEST(test_config_parameter_stored_from_json);
+  RUN_TEST(test_config_parameter_clear_data);
 
   UNITY_END();
 }

--- a/test/embedded/main.cpp
+++ b/test/embedded/main.cpp
@@ -4,15 +4,23 @@
 #include <unity.h>
 
 #include "ConfigParameterTest.h"
+#include "ConfigStringParameterTest.h"
 
 void setup() {
   delay(2000);
   UNITY_BEGIN();
 
+  // ConfigParameterTest
   RUN_TEST(test_sets_config_parameter_mode);
   RUN_TEST(test_config_parameter_stored_as_json);
   RUN_TEST(test_config_parameter_stored_from_json);
   RUN_TEST(test_config_parameter_clear_data);
+
+  // ConfigStringParameterTest
+  RUN_TEST(test_sets_config_string_parameter_mode);
+  RUN_TEST(test_config_string_parameter_stored_as_json);
+  RUN_TEST(test_config_string_parameter_stored_from_json);
+  RUN_TEST(test_config_string_parameter_clear_data);
 
   UNITY_END();
 }


### PR DESCRIPTION
This PR addresses the fact that there are a few classes tucked away inside `ConfigManager.h`.

It moves `BaseParameter`, and it's associated classes, into their own header file. As well as moving the debugging definitions into their own file.

This also functions as POC for using the `lib` directory for classes that are directly used by users of the library.